### PR TITLE
remove stray argument from windowsSocket::sendRawNonBlocking

### DIFF
--- a/src/platforms/windows/windowsSocket.cpp
+++ b/src/platforms/windows/windowsSocket.cpp
@@ -270,7 +270,7 @@ void windowsSocket::sendRaw(const char* buffer, const size_type count)
 }
 
 
-windowsSocket::size_type windowsSocket::sendRawNonBlocking(const char* buffer, const size_type count, const bool block)
+windowsSocket::size_type windowsSocket::sendRawNonBlocking(const char* buffer, const size_type count)
 {
 	m_status &= ~STATUS_WOULDBLOCK;
 


### PR DESCRIPTION
follow-up to 3e9e8c9265f722d294c0060e1ccf29695fa5d2eb
