### PR TITLE
Make serviceFactory::create throw instead of dying for invalid protocols

### DIFF
--- a/src/vmime/net/serviceFactory.cpp
+++ b/src/vmime/net/serviceFactory.cpp
@@ -60,7 +60,10 @@ shared_ptr <service> serviceFactory::create
 	(shared_ptr <session> sess, const string& protocol,
 	 shared_ptr <security::authenticator> auth)
 {
-	return (getServiceByProtocol(protocol)->create(sess, auth));
+	shared_ptr <const serviceFactory::registeredService> rserv = getServiceByProtocol(protocol);
+	if(!rserv)
+		throw exception("Service not found for protocol: "+protocol);
+	return rserv->create(sess, auth);
 }
 
 


### PR DESCRIPTION
Currently specifying an non-existing protocol for serviceFactory::create deferences a null shared_ptr, this patch throws an exception instead.
