### PR TITLE
Missing param in charsetConverter_win header breaking win build

### DIFF
--- a/src/vmime/charsetConverter_win.hpp
+++ b/src/vmime/charsetConverter_win.hpp
@@ -67,7 +67,7 @@ public:
 	void convert(utility::inputStream& in, utility::outputStream& out, status* st);
 
 	shared_ptr <utility::charsetFilteredOutputStream>
-		getFilteredOutputStream(utility::outputStream& os);
+		getFilteredOutputStream(utility::outputStream& os, const charsetConverterOptions& opts);
 
 private:
 


### PR DESCRIPTION
Small change, implementation had two parameters and header only had one.