### PR TITLE
Skip multiple (bogus) colons after header field name

### DIFF
--- a/src/vmime/headerField.cpp
+++ b/src/vmime/headerField.cpp
@@ -135,7 +135,8 @@ shared_ptr <headerField> headerField::parseNext
 				                  buffer.begin() + nameEnd);
 
 				// Skip ':' character
-				++pos;
+				while (pos < end && buffer[pos] == ':')
+					++pos;
 
 				// Skip spaces between ':' and the field contents
 				while (pos < end && (buffer[pos] == ' ' || buffer[pos] == '\t'))


### PR DESCRIPTION
Some (broken) implementation sends double-colons for certain fields, and this change makes vmime support that case.

Or maybe we should introduce a flag in the library context, settable by the library-using program, to toggle this behavior whether to be rfc-strict or not… thoughts?