### PR TITLE
Added const overload for certificateException::getCertificate().

### DIFF
--- a/src/vmime/security/cert/certificateException.cpp
+++ b/src/vmime/security/cert/certificateException.cpp
@@ -70,6 +70,12 @@ shared_ptr <certificate> certificateException::getCertificate()
 }
 
 
+shared_ptr <const certificate> certificateException::getCertificate() const
+{
+	return m_cert;
+}
+
+
 } // cert
 } // security
 } // vmime

--- a/src/vmime/security/cert/certificateException.hpp
+++ b/src/vmime/security/cert/certificateException.hpp
@@ -73,6 +73,12 @@ public:
 	  */
 	shared_ptr <certificate> getCertificate();
 
+	/** Returns the certificate on which the problem occured.
+	  *
+	  * @return certificate
+	  */
+	shared_ptr <const certificate> getCertificate() const;
+
 private:
 
 	shared_ptr <certificate> m_cert;


### PR DESCRIPTION
Allows querying the certificate info in exception handlers catching the exception by const reference, besides other uses.