### PR TITLE
Add option to specify if vmime should wrap (Message|Content)-Id

### DIFF
--- a/src/vmime/generationContext.cpp
+++ b/src/vmime/generationContext.cpp
@@ -33,6 +33,7 @@ generationContext::generationContext()
 	  m_prologText("This is a multi-part message in MIME format. Your mail reader " \
 	               "does not understand MIME message format."),
 	  m_epilogText(""),
+	  m_wrapMessageId(true),
 	  m_paramValueMode(PARAMETER_VALUE_RFC2231_ONLY)
 {
 }
@@ -43,6 +44,7 @@ generationContext::generationContext(const generationContext& ctx)
 	  m_maxLineLength(ctx.m_maxLineLength),
 	  m_prologText(ctx.m_prologText),
 	  m_epilogText(ctx.m_epilogText),
+	  m_wrapMessageId(ctx.m_wrapMessageId),
 	  m_paramValueMode(ctx.m_paramValueMode)
 {
 }
@@ -65,6 +67,7 @@ void generationContext::setMaxLineLength(const size_t maxLineLength)
 {
 	m_maxLineLength = maxLineLength;
 }
+
 
 
 const string generationContext::getPrologText() const
@@ -90,6 +93,15 @@ void generationContext::setEpilogText(const string& epilogText)
 	m_epilogText = epilogText;
 }
 
+bool generationContext::getWrapMessageId() const
+{
+	return m_wrapMessageId;
+}
+
+void generationContext::setWrapMessageId(const bool& wrapMessageId) 
+{
+	m_wrapMessageId = wrapMessageId;
+}
 
 void generationContext::setEncodedParameterValueMode(const EncodedParameterValueModes mode)
 {

--- a/src/vmime/generationContext.hpp
+++ b/src/vmime/generationContext.hpp
@@ -82,6 +82,25 @@ public:
 	  */
 	void setEpilogText(const string& epilogText);
 
+	/** Returns a boolean variable that indicates whether the
+	  * message id can be wrapped or not, i.e. from
+	  *
+	  * Message-Id: <very very long@domain>
+          *
+          * to
+          *
+          * Message-Id:
+          *  <very very long@domain>
+	  *
+	  * @return boolean indicating if the Message-Id can be wrapped
+	  */
+	bool getWrapMessageId() const;
+
+	/** Sets the boolean variable that indicates whether the
+	  * Message-Id can be wrapped or not
+          */
+	void setWrapMessageId(const bool& wrapMessageId);
+
 	/** Modes available for generating values in parameterized header fields.
 	  */
 	enum EncodedParameterValueModes
@@ -142,6 +161,7 @@ protected:
 
 	string m_prologText;
 	string m_epilogText;
+	bool m_wrapMessageId;
 
 	EncodedParameterValueModes m_paramValueMode;
 };

--- a/src/vmime/messageId.cpp
+++ b/src/vmime/messageId.cpp
@@ -193,7 +193,7 @@ void messageId::generateImpl
 {
 	size_t pos = curLinePos;
 
-	if (curLinePos + m_left.length() + m_right.length() + 3 > ctx.getMaxLineLength())
+	if (ctx.getWrapMessageId() && (curLinePos + m_left.length() + m_right.length() + 3 > ctx.getMaxLineLength()))
 	{
 		os << NEW_LINE_SEQUENCE;
 		pos = NEW_LINE_SEQUENCE_LENGTH;


### PR DESCRIPTION
Some MUAs (at least Outlook) has problems on Content-Id being wrapped,
therefore it is desired to turn what off. By wrapping Content-Id we
mean:

Content-Id: <jira-generated-image-avatar-.................................................>

becomes

Content-Id:
 <jira-generated-image-avatar-.................................................>

An option has been added to GenerationContext to force the
wrapping off (GenerationContext::setWrapMessageId(false)).

Fixes issue #154 

Signed-off-by: Bo Simonsen <b.simonsen@kopano.com>