### PR TITLE
ensure user defined parsingContext is passed forward on calls to parse

### DIFF
--- a/src/vmime/body.cpp
+++ b/src/vmime/body.cpp
@@ -128,7 +128,7 @@ size_t body::findNextBoundaryPosition
 
 
 void body::parseImpl
-	(const parsingContext& /* ctx */,
+	(const parsingContext& ctx,
 	 shared_ptr <utility::parserInputStreamAdapter> parser,
 	 const size_t position, const size_t end, size_t* newPosition)
 {
@@ -286,7 +286,7 @@ void body::parseImpl
 				if (partEnd > partStart)
 				{
 					vmime::text text;
-					text.parse(parser, partStart, partEnd);
+					text.parse(ctx, parser, partStart, partEnd);
 
 					m_prologText = text.getWholeBuffer();
 				}
@@ -304,7 +304,7 @@ void body::parseImpl
 				if (partEnd < partStart)
 					std::swap(partStart, partEnd);
 
-				part->parse(parser, partStart, partEnd, NULL);
+				part->parse(ctx, parser, partStart, partEnd, NULL);
 
 				m_parts.push_back(part);
 			}
@@ -325,7 +325,7 @@ void body::parseImpl
 
 			try
 			{
-				part->parse(parser, partStart, end);
+				part->parse(ctx, parser, partStart, end);
 			}
 			catch (std::exception&)
 			{
@@ -338,7 +338,7 @@ void body::parseImpl
 		else if (partStart < end)
 		{
 			vmime::text text;
-			text.parse(parser, partStart, end);
+			text.parse(ctx, parser, partStart, end);
 
 			m_epilogText = text.getWholeBuffer();
 		}

--- a/src/vmime/headerField.cpp
+++ b/src/vmime/headerField.cpp
@@ -114,31 +114,31 @@ shared_ptr <headerField> headerField::parseNext
 			const size_t nameEnd = pos;
 
 			while (pos < end && (buffer[pos] == ' ' || buffer[pos] == '\t'))
-        ++pos;
+				++pos;
 
 			if (buffer[pos] != ':')
 			{
 				switch (ctx.getHeaderParseErrorRecoveryMethod()) {
-          case vmime::headerParseRecoveryMethod::SKIP_LINE:
-          // Humm...does not seem to be a valid header line.
-          // Skip this error and advance to the next line
-          pos = nameStart;
+					case vmime::headerParseRecoveryMethod::SKIP_LINE:
+						// Humm...does not seem to be a valid header line.
+						// Skip this error and advance to the next line
+						pos = nameStart;
 
-          while (pos < end && buffer[pos] != '\n')
-            ++pos;
+						while (pos < end && buffer[pos] != '\n')
+							++pos;
 
-          if (pos < end && buffer[pos] == '\n')
-            ++pos;
-              break;
+						if (pos < end && buffer[pos] == '\n')
+							++pos;
+						break;
 
-//          case vmime::headerParseRecoveryMethod::APPEND_TO_PREVIOUS_LINE:
-//            // TODO Implement this...
-//            break;
+//					case vmime::headerParseRecoveryMethod::APPEND_TO_PREVIOUS_LINE:
+//						// TODO Implement this...
+//						break;
 
-          case vmime::headerParseRecoveryMethod::ASSUME_END_OF_HEADERS:
-            return null;
-            break;
-        }
+					case vmime::headerParseRecoveryMethod::ASSUME_END_OF_HEADERS:
+						return null;
+						break;
+				}
 			}
 			else
 			{

--- a/src/vmime/parsingContext.cpp
+++ b/src/vmime/parsingContext.cpp
@@ -47,13 +47,13 @@ parsingContext& parsingContext::getDefaultContext()
 
 headerParseRecoveryMethod::headerLineError parsingContext::getHeaderParseErrorRecoveryMethod() const
 {
-  return m_headerParseErrorRecovery;
+	return m_headerParseErrorRecovery;
 }
 
 
 void parsingContext::setHeaderParseErrorRecoveryMethod(headerParseRecoveryMethod::headerLineError recoveryMethod)
 {
-  m_headerParseErrorRecovery = recoveryMethod;
+	m_headrParseErrorRecovery = recoveryMethod;
 }
 
 

--- a/src/vmime/parsingContext.cpp
+++ b/src/vmime/parsingContext.cpp
@@ -53,7 +53,7 @@ headerParseRecoveryMethod::headerLineError parsingContext::getHeaderParseErrorRe
 
 void parsingContext::setHeaderParseErrorRecoveryMethod(headerParseRecoveryMethod::headerLineError recoveryMethod)
 {
-	m_headrParseErrorRecovery = recoveryMethod;
+	m_headerParseErrorRecovery = recoveryMethod;
 }
 
 

--- a/src/vmime/parsingContext.cpp
+++ b/src/vmime/parsingContext.cpp
@@ -28,13 +28,13 @@ namespace vmime
 {
 
 
-parsingContext::parsingContext()
+parsingContext::parsingContext() : m_headerParseErrorRecovery(vmime::headerParseRecoveryMethod::SKIP_LINE)
 {
 }
 
 
 parsingContext::parsingContext(const parsingContext& ctx)
-	: context(ctx)
+	: context(ctx), m_headerParseErrorRecovery(vmime::headerParseRecoveryMethod::SKIP_LINE)
 {
 }
 
@@ -43,6 +43,17 @@ parsingContext& parsingContext::getDefaultContext()
 {
 	static parsingContext ctx;
 	return ctx;
+}
+
+headerParseRecoveryMethod::headerLineError parsingContext::getHeaderParseErrorRecoveryMethod() const
+{
+  return m_headerParseErrorRecovery;
+}
+
+
+void parsingContext::setHeaderParseErrorRecoveryMethod(headerParseRecoveryMethod::headerLineError recoveryMethod)
+{
+  m_headerParseErrorRecovery = recoveryMethod;
 }
 
 

--- a/src/vmime/parsingContext.hpp
+++ b/src/vmime/parsingContext.hpp
@@ -31,6 +31,15 @@
 namespace vmime
 {
 
+  /** Provides runtime configurable options to provide flexibility in header parsing
+   */
+  struct headerParseRecoveryMethod {
+    enum headerLineError {
+      SKIP_LINE = 0,
+      /* APPEND_TO_PREVIOUS_LINE = 1, */
+      ASSUME_END_OF_HEADERS = 2
+    };
+  };
 
 /** Holds configuration parameters used for parsing messages.
   */
@@ -48,8 +57,22 @@ public:
 	  */
 	static parsingContext& getDefaultContext();
 
+  /** Sets the recovery method when parsing a header encounters an error such as a failed fold or missing new line.
+    *
+    * @param recoveryMethod is one of vmime::headerParseRecoveryMethod.  Defaults to vmime::headerParseRecoveryMethod::SKIP_LINE.
+    */
+  void setHeaderParseErrorRecoveryMethod(headerParseRecoveryMethod::headerLineError recoveryMethod);
+
+  /** Return the recovery method when parsing a header encounters an error.
+    *
+    * @return is an enum from vmime::headerParseRecoveryMethod
+    */
+  headerParseRecoveryMethod::headerLineError getHeaderParseErrorRecoveryMethod() const;
+
+
 protected:
 
+  headerParseRecoveryMethod::headerLineError m_headerParseErrorRecovery;
 };
 
 

--- a/src/vmime/parsingContext.hpp
+++ b/src/vmime/parsingContext.hpp
@@ -31,15 +31,15 @@
 namespace vmime
 {
 
-  /** Provides runtime configurable options to provide flexibility in header parsing
-   */
-  struct headerParseRecoveryMethod {
-    enum headerLineError {
-      SKIP_LINE = 0,
-      /* APPEND_TO_PREVIOUS_LINE = 1, */
-      ASSUME_END_OF_HEADERS = 2
-    };
-  };
+	/** Provides runtime configurable options to provide flexibility in header parsing
+	 */
+	struct headerParseRecoveryMethod {
+		enum headerLineError {
+			SKIP_LINE = 0,
+			/* APPEND_TO_PREVIOUS_LINE = 1, */
+			ASSUME_END_OF_HEADERS = 2
+		};
+	};
 
 /** Holds configuration parameters used for parsing messages.
   */
@@ -57,22 +57,22 @@ public:
 	  */
 	static parsingContext& getDefaultContext();
 
-  /** Sets the recovery method when parsing a header encounters an error such as a failed fold or missing new line.
-    *
-    * @param recoveryMethod is one of vmime::headerParseRecoveryMethod.  Defaults to vmime::headerParseRecoveryMethod::SKIP_LINE.
-    */
-  void setHeaderParseErrorRecoveryMethod(headerParseRecoveryMethod::headerLineError recoveryMethod);
+	/** Sets the recovery method when parsing a header encounters an error such as a failed fold or missing new line.
+	  *
+	  * @param recoveryMethod is one of vmime::headerParseRecoveryMethod.  Defaults to vmime::headerParseRecoveryMethod::SKIP_LINE.
+	  */
+	void setHeaderParseErrorRecoveryMethod(headerParseRecoveryMethod::headerLineError recoveryMethod);
 
-  /** Return the recovery method when parsing a header encounters an error.
-    *
-    * @return is an enum from vmime::headerParseRecoveryMethod
-    */
-  headerParseRecoveryMethod::headerLineError getHeaderParseErrorRecoveryMethod() const;
+	/** Return the recovery method when parsing a header encounters an error.
+	  *
+	  * @return is an enum from vmime::headerParseRecoveryMethod
+	  */
+	headerParseRecoveryMethod::headerLineError getHeaderParseErrorRecoveryMethod() const;
 
 
 protected:
 
-  headerParseRecoveryMethod::headerLineError m_headerParseErrorRecovery;
+	headerParseRecoveryMethod::headerLineError m_headerParseErrorRecovery;
 };
 
 


### PR DESCRIPTION
With no options in `parserContext` this would likely go unnoticed as the passed version would match the default generated version.  This change passes the incoming `parsingContext` to the calls to `parse` and will allow `parsingContext` to be extended with additional options to control the parsers' behavior.

This change will be a dependency #164 