### PR TITLE
Remove unnecesary public in vmime::enconding

### DIFF
--- a/src/vmime/encoding.hpp
+++ b/src/vmime/encoding.hpp
@@ -58,8 +58,6 @@ public:
 	encoding(const string& name, const EncodingUsage usage);
 	encoding(const encoding& enc);
 
-public:
-
 	/** Return the name of the encoding.
 	  * See the constants in vmime::encodingTypes.
 	  *


### PR DESCRIPTION
This class has another "public" just five lines befores