### PR TITLE
Handle parsing of a@b.c <e@f.g>

### DIFF
--- a/src/vmime/mailbox.cpp
+++ b/src/vmime/mailbox.cpp
@@ -234,8 +234,6 @@ void mailbox::parseImpl
 
 					++p;
 				}
-
-				break;
 			}
 			else
 			{
@@ -245,10 +243,6 @@ void mailbox::parseImpl
 		}
 		else if (state == State_Address)
 		{
-			// Skip '<' character
-			if (*p == '<')
-				++p;
-
 			bool escaped = false;
 			int comment = 0;
 


### PR DESCRIPTION
The behavior of current VMIME implementation will result in address a@b.c
with an empty name. That is because the parsing is stopped whenever a
wihtespace and a at-character is seen. We should continue the parsing to
deduce the real address (e@f.g in the example).