### PR TITLE
Avoid extern "C" blocks around ICU includes

### DIFF
--- a/src/vmime/charsetConverter_icu.cpp
+++ b/src/vmime/charsetConverter_icu.cpp
@@ -34,15 +34,12 @@
 #include "vmime/utility/outputStreamStringAdapter.hpp"
 
 
-extern "C" {
-
 #ifndef VMIME_BUILDING_DOC
 
 	#include <unicode/ucnv.h>
 	#include <unicode/ucnv_err.h>
 
 #endif // VMIME_BUILDING_DOC
-}
 
 
 #include <unicode/unistr.h>


### PR DESCRIPTION
Looks like it's not necessary, and, moreover, I'm getting this with recent ICU (64.2):
```
/usr/include/unicode/localpointer.h:67:1: error: template with C linkage
   67 | template<typename T>
      | ^~~~~~~~
/var/tmp/portage/dev-libs/vmime-9999/work/vmime-9999/src/vmime/charsetConverter_icu.cpp:37:1: note: ‘extern "C"’ linkage started here
   37 | extern "C" {
      | ^~~~~~~~~~
```

(there's also an issue about that, #218)