### PR TITLE
Set SNI in the openssl backend

### DIFF
--- a/src/vmime/net/tls/gnutls/TLSSocket_GnuTLS.cpp
+++ b/src/vmime/net/tls/gnutls/TLSSocket_GnuTLS.cpp
@@ -94,6 +94,8 @@ void TLSSocket_GnuTLS::connect(const string& address, const port_t port) {
 
 	try {
 
+		gnutls_server_name_set(*m_session->m_gnutlsSession, GNUTLS_NAME_DNS, address.c_str(), address.size());
+
 		m_wrapped->connect(address, port);
 
 		handshake();

--- a/src/vmime/net/tls/openssl/TLSSocket_OpenSSL.cpp
+++ b/src/vmime/net/tls/openssl/TLSSocket_OpenSSL.cpp
@@ -123,6 +123,10 @@ void TLSSocket_OpenSSL::createSSLHandle() {
 
 	if (m_wrapped->isConnected()) {
 
+		if (m_address.empty()) {
+			throw exceptions::tls_exception("Unknown host name, will not be able to set SNI");
+		}
+
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
 
 		BIO* sockBio = BIO_new(&sm_customBIOMethod);
@@ -163,6 +167,7 @@ void TLSSocket_OpenSSL::createSSLHandle() {
 		}
 
 		SSL_set_bio(m_ssl, sockBio, sockBio);
+		SSL_set_tlsext_host_name(m_ssl, m_address.c_str());
 		SSL_set_connect_state(m_ssl);
 		SSL_set_mode(m_ssl, SSL_MODE_AUTO_RETRY | SSL_MODE_ENABLE_PARTIAL_WRITE | SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER);
 
@@ -178,6 +183,7 @@ void TLSSocket_OpenSSL::connect(const string& address, const port_t port) {
 	try {
 
 		m_wrapped->connect(address, port);
+		m_address = address;
 
 		createSSLHandle();
 

--- a/src/vmime/net/tls/openssl/TLSSocket_OpenSSL.hpp
+++ b/src/vmime/net/tls/openssl/TLSSocket_OpenSSL.hpp
@@ -116,6 +116,8 @@ private:
 
 	shared_ptr <socket> m_wrapped;
 
+	std::string m_address;
+
 	bool m_connected;
 
 	byte_t m_buffer[65536];


### PR DESCRIPTION
GMail in particular started requiring SNI lately. This change allows setting the SNI in the OpenSSL implementation of SSL sockets.

I cannot say I super like this approach — saving the address to `m_address` seems meh, but `createSSSLHandle()` seems to be used in contexts where the user doesn't pass the address explicitly.