### PR TITLE
Body type parsing

### DIFF
--- a/src/vmime/net/imap/IMAPMessagePart.cpp
+++ b/src/vmime/net/imap/IMAPMessagePart.cpp
@@ -87,6 +87,8 @@ IMAPMessagePart::IMAPMessagePart(
 
 		m_size = part->body_type_text->body_fields->body_fld_octets->value;
 
+		m_name = getPartName(part->body_type_text);
+
 	} else if (part->body_type_msg) {
 
 		m_mediaType = vmime::mediaType(

--- a/src/vmime/net/imap/IMAPMessagePart.cpp
+++ b/src/vmime/net/imap/IMAPMessagePart.cpp
@@ -52,6 +52,21 @@ IMAPMessagePart::IMAPMessagePart(
 	);
 }
 
+namespace {
+	template<typename T>
+	vmime::string getPartName(const T& body_type) {
+		if (const auto* pparam = body_type->body_fields->body_fld_param.get()) {
+			for (const auto& param : pparam->items) {
+				if (param->string1->value == "NAME") {
+					return param->string2->value;
+				}
+			}
+		}
+
+		return {};
+	}
+}
+
 
 IMAPMessagePart::IMAPMessagePart(
 	const shared_ptr <IMAPMessagePart>& parent,
@@ -88,13 +103,7 @@ IMAPMessagePart::IMAPMessagePart(
 
 		m_size = part->body_type_basic->body_fields->body_fld_octets->value;
 
-		if (const auto* pparam = part->body_type_basic->body_fields->body_fld_param.get()) {
-			for (const auto& param : pparam->items) {
-				if (param->string1->value == "NAME") {
-					m_name = param->string2->value;
-				}
-			}
-		}
+		m_name = getPartName(part->body_type_basic);
 
 		if (part->body_ext_1part && part->body_ext_1part->body_fld_dsp) {
 			auto *cdisp = part->body_ext_1part->body_fld_dsp->str();

--- a/src/vmime/net/imap/IMAPMessagePart.cpp
+++ b/src/vmime/net/imap/IMAPMessagePart.cpp
@@ -106,12 +106,12 @@ IMAPMessagePart::IMAPMessagePart(
 		m_size = part->body_type_basic->body_fields->body_fld_octets->value;
 
 		m_name = getPartName(part->body_type_basic);
+	}
 
-		if (part->body_ext_1part && part->body_ext_1part->body_fld_dsp) {
-			auto *cdisp = part->body_ext_1part->body_fld_dsp->str();
-			if (cdisp) {
-				m_dispType = contentDisposition(cdisp->value);
-			}
+	if (part->body_ext_1part && part->body_ext_1part->body_fld_dsp) {
+		auto *cdisp = part->body_ext_1part->body_fld_dsp->str();
+		if (cdisp) {
+			m_dispType = contentDisposition(cdisp->value);
 		}
 	}
 


### PR DESCRIPTION
This makes the `IMAPMessagePart` more omnivorous, allowing text parts having a name, and trying to parse out content-disposition for any body part type.

I've actually seen messages where attachment names fail to be obtained if either of these changes is omitted, so looks like it's useful in practice.