### PR TITLE
Exceptions handling / re-throwing fixes

### DIFF
--- a/src/vmime/exception.hpp
+++ b/src/vmime/exception.hpp
@@ -34,6 +34,7 @@
 
 namespace vmime {
 
+typedef std::exception_ptr exception_ptr;
 
 /** Base class for VMime exceptions.
   */

--- a/src/vmime/net/imap/IMAPFolder.cpp
+++ b/src/vmime/net/imap/IMAPFolder.cpp
@@ -80,7 +80,11 @@ IMAPFolder::~IMAPFolder() {
 		if (store) {
 
 			if (m_open) {
-				close(false);
+				try {
+					close(false);
+				} catch (...) {
+					// Ignore exception here to make sure unregisterFolder is called
+				}
 			}
 
 			store->unregisterFolder(this);

--- a/src/vmime/net/tls/gnutls/TLSSocket_GnuTLS.cpp
+++ b/src/vmime/net/tls/gnutls/TLSSocket_GnuTLS.cpp
@@ -66,7 +66,7 @@ TLSSocket_GnuTLS::TLSSocket_GnuTLS(
 	: m_session(session),
 	  m_wrapped(sok),
 	  m_connected(false),
-	  m_ex(NULL),
+	  m_ex(nullptr),
 	  m_status(0),
 	  m_errno(0) {
 
@@ -407,7 +407,7 @@ ssize_t TLSSocket_GnuTLS::gnutlsPushFunc(
 
 		// Workaround for non-portable behaviour when throwing C++ exceptions
 		// from C functions (GNU TLS)
-		sok->m_ex = e.clone();
+		sok->m_ex = std::current_exception();
 		return -1;
 	}
 }
@@ -440,7 +440,7 @@ ssize_t TLSSocket_GnuTLS::gnutlsPullFunc(
 
 		// Workaround for non-portable behaviour when throwing C++ exceptions
 		// from C functions (GNU TLS)
-		sok->m_ex = e.clone();
+		sok->m_ex = std::current_exception();
 		return -1;
 	}
 }
@@ -525,18 +525,15 @@ shared_ptr <security::cert::certificateChain> TLSSocket_GnuTLS::getPeerCertifica
 
 void TLSSocket_GnuTLS::throwException() {
 
-	if (m_ex) {
-		throw *m_ex;
+	if (!!m_ex) {
+		std::rethrow_exception(m_ex);
 	}
 }
 
 
 void TLSSocket_GnuTLS::resetException() {
 
-	if (m_ex) {
-		delete m_ex;
-		m_ex = NULL;
-	}
+	m_ex = nullptr;
 }
 
 

--- a/src/vmime/net/tls/gnutls/TLSSocket_GnuTLS.hpp
+++ b/src/vmime/net/tls/gnutls/TLSSocket_GnuTLS.hpp
@@ -109,7 +109,7 @@ private:
 
 	byte_t m_buffer[65536];
 
-	exception* m_ex;
+	exception_ptr m_ex;
 
 	unsigned int m_status;
 	int m_errno;

--- a/src/vmime/net/tls/openssl/TLSSocket_OpenSSL.hpp
+++ b/src/vmime/net/tls/openssl/TLSSocket_OpenSSL.hpp
@@ -125,7 +125,7 @@ private:
 	unsigned int m_status;
 
 	// Last exception thrown from C BIO functions
-	scoped_ptr <exception> m_ex;
+	exception_ptr m_ex;
 };
 
 


### PR DESCRIPTION
net/tls: Refactored re-throwing exceptions so that the original exception class is retained. With the old code, a socket_exception was re-thrown as vmime::exception.

IMAPFolder.cpp: Fixed a use-after-free in case of an exception in close().