### PR TITLE
Fixed an ENVELOPE ReplyTo handling regression

### DIFF
--- a/src/vmime/net/imap/IMAPMessage.cpp
+++ b/src/vmime/net/imap/IMAPMessage.cpp
@@ -553,7 +553,7 @@ int IMAPMessage::processFetchResponse(
 					IMAPUtils::convertAddressList(*(env->env_reply_to), replyTo);
 
 					if (!replyTo.isEmpty()) {
-						hdr->ReplyTo()->setValue(*(replyTo.getMailboxAt(0)));
+						hdr->ReplyTo()->setValue(replyTo.toAddressList());
 					}
 
 					// Cc


### PR DESCRIPTION
Attempts to obtain the message would trigger bad_field_value_type exception if a ReplyTo header field was present.