### PR TITLE
Default missing Content-Type to Text/Plain 

### DIFF
--- a/src/vmime/messageParser.cpp
+++ b/src/vmime/messageParser.cpp
@@ -204,7 +204,16 @@ bool messageParser::findSubTextParts(
 
 		} else {
 
-			// No "Content-type" field.
+			// No "Content-type" field. RFC2045 section 5.2 assumes this is TEXT/PLAIN
+			try {
+				shared_ptr <textPart> txtPart = textPartFactory::getInstance()->create(mediaType(mediaTypes::TEXT, mediaTypes::TEXT_PLAIN));
+				txtPart->parse(msg, part, p);
+
+				m_textParts.push_back(txtPart);
+			}
+			catch (exceptions::no_factory_available& e) {
+				// Content-type not recognized.
+			}
 		}
 	}
 


### PR DESCRIPTION
Default missing Content-Type to Text/Plain  as per https://tools.ietf.org/html/rfc2045#section-5.2

Such emails are routinely sent by https://en.wikipedia.org/wiki/YAM_(Yet_Another_Mailer) , but there's likely more mailers doing this.