### PR TITLE
Weak ptr checks + forced socket disconnections.

### DIFF
--- a/src/vmime/net/imap/IMAPConnection.hpp
+++ b/src/vmime/net/imap/IMAPConnection.hpp
@@ -114,6 +114,8 @@ public:
 
 private:
 
+	shared_ptr <IMAPStore> getStoreOrThrow();
+
 	void authenticate();
 #if VMIME_HAVE_SASL_SUPPORT
 	void authenticateSASL();

--- a/src/vmime/net/imap/IMAPMessage.cpp
+++ b/src/vmime/net/imap/IMAPMessage.cpp
@@ -243,7 +243,7 @@ void IMAPMessage::extract(
 	shared_ptr <const IMAPFolder> folder = m_folder.lock();
 
 	if (!folder) {
-		throw exceptions::illegal_state("Folder not open");
+		throw exceptions::folder_not_found();
 	}
 
 	extractImpl(

--- a/src/vmime/net/imap/IMAPMessagePartContentHandler.cpp
+++ b/src/vmime/net/imap/IMAPMessagePartContentHandler.cpp
@@ -36,7 +36,6 @@
 #include "vmime/utility/outputStreamAdapter.hpp"
 #include "vmime/utility/inputStreamStringAdapter.hpp"
 
-
 namespace vmime {
 namespace net {
 namespace imap {
@@ -70,6 +69,9 @@ void IMAPMessagePartContentHandler::generate(
 
 	shared_ptr <IMAPMessage> msg = m_message.lock();
 	shared_ptr <messagePart> part = m_part.lock();
+
+	if (!msg || !part)
+		throw exceptions::message_not_found();
 
 	// Data is already encoded
 	if (isEncoded()) {
@@ -140,6 +142,9 @@ void IMAPMessagePartContentHandler::extract(
 	shared_ptr <IMAPMessage> msg = m_message.lock();
 	shared_ptr <messagePart> part = m_part.lock();
 
+	if (!msg || !part)
+		throw exceptions::message_not_found();
+
 	// No decoding to perform
 	if (!isEncoded()) {
 
@@ -172,12 +177,17 @@ void IMAPMessagePartContentHandler::extractRaw(
 	shared_ptr <IMAPMessage> msg = m_message.lock();
 	shared_ptr <messagePart> part = m_part.lock();
 
+	if (!msg || !part)
+		throw exceptions::message_not_found();
+
 	msg->extractPart(part, os, progress);
 }
 
 
 size_t IMAPMessagePartContentHandler::getLength() const {
-
+	shared_ptr <messagePart> part = m_part.lock();
+	if (!part)
+		throw exceptions::message_not_found();
 	return m_part.lock()->getSize();
 }
 

--- a/src/vmime/net/imap/IMAPParser.hpp
+++ b/src/vmime/net/imap/IMAPParser.hpp
@@ -4912,6 +4912,9 @@ public:
 		shared_ptr <timeoutHandler> toh = m_timeoutHandler.lock();
 		shared_ptr <socket> sok = m_socket.lock();
 
+		if (!sok)
+			throw exceptions::illegal_state("Store disconnected");
+
 		if (toh) {
 			toh->resetTimeOut();
 		}
@@ -4956,6 +4959,9 @@ public:
 
 		shared_ptr <timeoutHandler> toh = m_timeoutHandler.lock();
 		shared_ptr <socket> sok = m_socket.lock();
+
+		if (!sok)
+			throw exceptions::illegal_state("Store disconnected");
 
 		if (m_progress) {
 			m_progress->start(count);

--- a/src/vmime/net/imap/IMAPStore.cpp
+++ b/src/vmime/net/imap/IMAPStore.cpp
@@ -179,9 +179,7 @@ shared_ptr <IMAPConnection> IMAPStore::getConnection() {
 
 void IMAPStore::disconnect() {
 
-	if (!isConnected()) {
-		throw exceptions::not_connected();
-	}
+	bool wasConnected = isConnected();
 
 	for (std::list <IMAPFolder*>::iterator it = m_folders.begin() ;
 	     it != m_folders.end() ; ++it) {
@@ -191,10 +189,14 @@ void IMAPStore::disconnect() {
 
 	m_folders.clear();
 
+	if (m_connection) {
+		m_connection->disconnect();
+		m_connection = null;
+	}
 
-	m_connection->disconnect();
-
-	m_connection = null;
+	if (!wasConnected) {
+		throw exceptions::not_connected();
+	}
 }
 
 


### PR DESCRIPTION
Added checks to several places that either used a weak_ptr directly or via weak_ptr<Foo>.lock()->method().
Ensure disconnect() methods always close and reset the socket pointers even if the sockets are already disconnected.