### PR TITLE
Prevent accessing empty buffer when using FilteredOutputStream with ICU

### DIFF
--- a/src/vmime/charsetConverter_icu.cpp
+++ b/src/vmime/charsetConverter_icu.cpp
@@ -433,8 +433,9 @@ void charsetFilteredOutputStream_icu::writeImpl(
 		}
 
 		const size_t uniLength = uniTarget - &uniBuffer[0];
-		if(uniLength == 0)
+		if(uniLength == 0) {
 			continue;
+		}
 
 		// Allocate buffer for destination charset
 		const size_t cpSize = ucnv_getMinCharSize(m_to) * uniLength;
@@ -522,8 +523,9 @@ void charsetFilteredOutputStream_icu::flush() {
 		}
 
 		const size_t uniLength = uniTarget - &uniBuffer[0];
-		if(uniLength == 0)
+		if(uniLength == 0) {
 			continue;
+		}
 
 		// Allocate buffer for destination charset
 		const size_t cpSize = ucnv_getMinCharSize(m_to) * uniLength;

--- a/src/vmime/charsetConverter_icu.cpp
+++ b/src/vmime/charsetConverter_icu.cpp
@@ -433,6 +433,8 @@ void charsetFilteredOutputStream_icu::writeImpl(
 		}
 
 		const size_t uniLength = uniTarget - &uniBuffer[0];
+		if(uniLength == 0)
+			continue;
 
 		// Allocate buffer for destination charset
 		const size_t cpSize = ucnv_getMinCharSize(m_to) * uniLength;
@@ -520,6 +522,8 @@ void charsetFilteredOutputStream_icu::flush() {
 		}
 
 		const size_t uniLength = uniTarget - &uniBuffer[0];
+		if(uniLength == 0)
+			continue;
 
 		// Allocate buffer for destination charset
 		const size_t cpSize = ucnv_getMinCharSize(m_to) * uniLength;


### PR DESCRIPTION
charsetFilteredOutputStream_icu::writeImpl() is accessing element in an empty buffer which is undefined behaviour.
I have added a test so that code analysis tool can detect this issue.