### PR TITLE
Fixes #283

### DIFF
--- a/src/vmime/text.cpp
+++ b/src/vmime/text.cpp
@@ -338,6 +338,11 @@ void text::createFromString(const string& in, const charset& ch) {
 
 					} else {
 
+						if (count) {
+							shared_ptr <word> w = getWordAt(getWordCount() - 1);
+							w->getBuffer() += ' ';
+						}
+
 						appendWord(make_shared <word>(chunk, charset(charsets::US_ASCII)));
 
 						prevIs8bit = false;


### PR DESCRIPTION
Prevents the loss of a space if the previous word is 8-bit but the current one is not. This equals the case of the current word being 8-bit but not the previous one.