### PR TITLE
Avoid generating illegal Envelope-From with sendmail:// transport

### DIFF
--- a/src/vmime/net/sendmail/sendmailTransport.cpp
+++ b/src/vmime/net/sendmail/sendmailTransport.cpp
@@ -165,7 +165,7 @@ void sendmailTransport::send(
 	args.push_back("-i");
 	args.push_back("-f");
 
-	if (!sender.isEmpty()) {
+	if (sender.isEmpty()) {
 		args.push_back(expeditor.getEmail().generate());
 	} else {
 		args.push_back(sender.getEmail().generate());


### PR DESCRIPTION
When the ``sender`` function argument is the empty object, vmime would still attempt to use it at ``sender.getEmail().generate()``, but that produces just ``@``. As sendmail is called with ``-f @``, this shows up in postfix's logs as ``<""@>``.