### PR TITLE
Make default context thread_local

### DIFF
--- a/src/vmime/parsingContext.cpp
+++ b/src/vmime/parsingContext.cpp
@@ -42,7 +42,7 @@ parsingContext::parsingContext(const parsingContext& ctx)
 
 parsingContext& parsingContext::getDefaultContext() {
 
-	static parsingContext ctx;
+	static thread_local parsingContext ctx;
 	return ctx;
 }
 

--- a/src/vmime/parsingContext.hpp
+++ b/src/vmime/parsingContext.hpp
@@ -42,6 +42,12 @@ struct headerParseRecoveryMethod {
 };
 
 /** Holds configuration parameters used for parsing messages.
+  *
+  * Within vmime there are some functions that only utilize the default parsing
+  *  context. If you need to manipulate the behavior of the parser for those
+  *  functions, it is suggested to get the default context and make the
+  *  appropriate set calls to adjust the behavior. You can also use this
+  *  instance when making function calls the require a context be passed in.
   */
 class VMIME_EXPORT parsingContext : public context {
 
@@ -50,9 +56,10 @@ public:
 	parsingContext();
 	parsingContext(const parsingContext& ctx);
 
-	/** Returns the default context used for parsing messages.
+	/** Returns the default context used for parsing messages. The context
+    *  is scoped as a thread local variable.
 	  *
-	  * @return a reference to the default parsing context
+	  * @return a reference to the default parsing context for that thread
 	  */
 	static parsingContext& getDefaultContext();
 

--- a/src/vmime/parsingContext.hpp
+++ b/src/vmime/parsingContext.hpp
@@ -57,7 +57,7 @@ public:
 	parsingContext(const parsingContext& ctx);
 
 	/** Returns the default context used for parsing messages. The context
-    *  is scoped as a thread local variable.
+	  * is scoped as a thread local variable.
 	  *
 	  * @return a reference to the default parsing context for that thread
 	  */


### PR DESCRIPTION
This has the potential to come into play more with #280 (parsing failure feedback).  It also comes into play with how we elected to patch for #235 (emailAddress adds domain).

This change makes the default context a thread_local item to prevent any potential issues with with multiple threads wanting to configure/adjust the behavior of the default context simultaneously.