### PR TITLE
url: repair off-by-one bug in extractHost

### DIFF
--- a/src/vmime/utility/url.cpp
+++ b/src/vmime/utility/url.cpp
@@ -180,7 +180,7 @@ static bool extractHostIPv6(string& hostPart, string& host, string& port) {
 
 	host.assign(&hostPart[1], len - 1);
 
-	if (hostPart[len] == '\0') {
+	if (hostPart[len + 1] == '\0') {
 		return true;
 	}
 	if (hostPart[len + 1] != ':') {

--- a/tests/utility/urlTest.cpp
+++ b/tests/utility/urlTest.cpp
@@ -35,7 +35,8 @@ VMIME_TEST_SUITE_BEGIN(urlTest)
 		VMIME_TEST(testParse3)
 		VMIME_TEST(testParse4)
 		VMIME_TEST(testParse5)
-		VMIME_TEST(testParseIPv6)
+		VMIME_TEST(testParseIPv6Full)
+		VMIME_TEST(testParseIPv6NoPort)
 		VMIME_TEST(testGenerate)
 		VMIME_TEST(testUtilsEncode)
 		VMIME_TEST(testUtilsDecode)
@@ -202,7 +203,7 @@ VMIME_TEST_SUITE_BEGIN(urlTest)
 		VASSERT_EQ("4", "myserver.com", u1.getHost());
 	}
 
-	void testParseIPv6() {
+	void testParseIPv6Full() {
 
 		vmime::utility::url u1("", "");
 
@@ -212,6 +213,14 @@ VMIME_TEST_SUITE_BEGIN(urlTest)
 		VASSERT_EQ("4", "::1", u1.getHost());
 		VASSERT_EQ("5", 80, u1.getPort());
 		VASSERT_EQ("6", "/p", u1.getPath());
+	}
+
+	void testParseIPv6NoPort() {
+
+		vmime::utility::url u1("", "");
+
+		VASSERT_EQ("1", true, parseHelper(u1, "http://[::1]/"));
+		VASSERT_EQ("2", "::1", u1.getHost());
 	}
 
 	void testGenerate() {


### PR DESCRIPTION
`hostPart[len]` is pointing to `]`, but we need to check the char after that.

Fixes: v0.9.2-187-g874a1d8c