### PR TITLE
url: strip leading slash from url-path

### DIFF
--- a/src/vmime/utility/url.cpp
+++ b/src/vmime/utility/url.cpp
@@ -274,8 +274,19 @@ void url::parse(const string& str) {
 	extractHost(hostPart, host, port);
 
 	// Path
-	string path = utility::stringUtils::trim(string(str.begin() + slashPos, str.end()));
+	string path;
 	string params;
+
+	if (slashPos != str.size()) {
+
+		// Cf. RFC 1738 §3.1 page 6. For all URLs that follow Common
+		// Internet Scheme Syntax (and this parser demands it by only
+		// allowing URLs with "://" above), the separator is not
+		// actually part of the path.
+		auto pathStart = slashPos + 1;
+		path = utility::stringUtils::trim(string(str.begin() + pathStart, str.end()));
+
+	}
 
 	size_t paramSep = path.find_first_of('?');
 
@@ -283,10 +294,6 @@ void url::parse(const string& str) {
 
 		params = string(path.begin() + paramSep + 1, path.end());
 		path.erase(path.begin() + paramSep, path.end());
-	}
-
-	if (path == "/") {
-		path.clear();
 	}
 
 	// Some sanity check

--- a/tests/utility/urlTest.cpp
+++ b/tests/utility/urlTest.cpp
@@ -71,7 +71,7 @@ VMIME_TEST_SUITE_BEGIN(urlTest)
 		VASSERT_EQ("1.4", "password", u1.getPassword());
 		VASSERT_EQ("1.5", "host", u1.getHost());
 		VASSERT_EQ("1.6", 12345, u1.getPort());
-		VASSERT_EQ("1.7", "/path/", u1.getPath());
+		VASSERT_EQ("1.7", "path/", u1.getPath());
 
 		vmime::utility::url u2("", "");
 
@@ -81,7 +81,7 @@ VMIME_TEST_SUITE_BEGIN(urlTest)
 		VASSERT_EQ("2.4", "", u2.getPassword());
 		VASSERT_EQ("2.5", "host", u2.getHost());
 		VASSERT_EQ("2.6", 12345, u2.getPort());
-		VASSERT_EQ("2.7", "/path/", u2.getPath());
+		VASSERT_EQ("2.7", "path/", u2.getPath());
 
 		vmime::utility::url u3("", "");
 
@@ -91,7 +91,7 @@ VMIME_TEST_SUITE_BEGIN(urlTest)
 		VASSERT_EQ("3.4", "", u3.getPassword());
 		VASSERT_EQ("3.5", "host", u3.getHost());
 		VASSERT_EQ("3.6", 12345, u3.getPort());
-		VASSERT_EQ("3.7", "/path/", u3.getPath());
+		VASSERT_EQ("3.7", "path/", u3.getPath());
 
 		vmime::utility::url u4("", "");
 
@@ -101,7 +101,7 @@ VMIME_TEST_SUITE_BEGIN(urlTest)
 		VASSERT_EQ("4.4", "", u4.getPassword());
 		VASSERT_EQ("4.5", "host", u4.getHost());
 		VASSERT_EQ("4.6", vmime::utility::url::UNSPECIFIED_PORT, u4.getPort());
-		VASSERT_EQ("4.7", "/path/", u4.getPath());
+		VASSERT_EQ("4.7", "path/", u4.getPath());
 
 		vmime::utility::url u5("", "");
 
@@ -121,7 +121,7 @@ VMIME_TEST_SUITE_BEGIN(urlTest)
 		VASSERT_EQ("6.4", "", u4.getPassword());
 		VASSERT_EQ("6.5", "host", u4.getHost());
 		VASSERT_EQ("6.6", vmime::utility::url::UNSPECIFIED_PORT, u4.getPort());
-		VASSERT_EQ("6.7", "/path/file", u4.getPath());
+		VASSERT_EQ("6.7", "path/file", u4.getPath());
 	}
 
 	void testParse2() {
@@ -156,7 +156,7 @@ VMIME_TEST_SUITE_BEGIN(urlTest)
 		VASSERT_EQ("1.4", "pass\x56word", u1.getPassword());
 		VASSERT_EQ("1.5", "ho\x78st", u1.getHost());
 		VASSERT_EQ("1.6", 12345, u1.getPort());
-		VASSERT_EQ("1.7", "/pa\xabth/", u1.getPath());
+		VASSERT_EQ("1.7", "pa\xabth/", u1.getPath());
 	}
 
 	void testParse4() {
@@ -167,14 +167,14 @@ VMIME_TEST_SUITE_BEGIN(urlTest)
 		VASSERT_EQ("1.1", true, parseHelper(u1, "proto://host/path?p1=v1&p2=v2"));
 		VASSERT_EQ("1.2", "v1", u1.getParams()["p1"]);
 		VASSERT_EQ("1.3", "v2", u1.getParams()["p2"]);
-		VASSERT_EQ("1.4", "/path", u1.getPath());
+		VASSERT_EQ("1.4", "path", u1.getPath());
 
 		vmime::utility::url u2("", "");
 
 		VASSERT_EQ("2.1", true, parseHelper(u2, "proto://host/path?p1=v1&p2"));
 		VASSERT_EQ("2.2", "v1", u2.getParams()["p1"]);
 		VASSERT_EQ("2.3", "p2", u2.getParams()["p2"]);
-		VASSERT_EQ("2.4", "/path", u2.getPath());
+		VASSERT_EQ("2.4", "path", u2.getPath());
 
 		vmime::utility::url u3("", "");
 
@@ -188,7 +188,7 @@ VMIME_TEST_SUITE_BEGIN(urlTest)
 		VASSERT_EQ("4.1", true, parseHelper(u4, "proto://host/path?p1=%3D&%3D=v2"));
 		VASSERT_EQ("4.2", "=", u4.getParams()["p1"]);
 		VASSERT_EQ("4.3", "v2", u4.getParams()["="]);
-		VASSERT_EQ("4.4", "/path", u4.getPath());
+		VASSERT_EQ("4.4", "path", u4.getPath());
 	}
 
 	// '@' symbol in the username part
@@ -211,7 +211,7 @@ VMIME_TEST_SUITE_BEGIN(urlTest)
 		VASSERT_EQ("3", "b", u1.getPassword());
 		VASSERT_EQ("4", "::1", u1.getHost());
 		VASSERT_EQ("5", 80, u1.getPort());
-		VASSERT_EQ("6", "/p", u1.getPath());
+		VASSERT_EQ("6", "p", u1.getPath());
 	}
 
 	void testGenerate() {


### PR DESCRIPTION
Observed:

1. `http://host/` leads to path=""
2. `http://host/a` leads to path="/a"

That can't be right. Either case 1 must produce path="/", or case 2 must produce path="a".
RFC says `/` is not part of the path, so we'll go for path="a".