### PR TITLE
vmime: avoid changing SEVEN_BIT when encoding::decideImpl sees U+007F

### DIFF
--- a/src/vmime/base.hpp
+++ b/src/vmime/base.hpp
@@ -232,23 +232,6 @@ namespace vmime {
 
 		return const_pointer_cast <X, Y>(obj);
 	}
-
-	/** Inherit from this class to indicate the subclass is not copyable,
-	  * ie. you want to prohibit copy construction and copy assignment.
-	  */
-	class VMIME_EXPORT noncopyable {
-
-	protected:
-
-		noncopyable() { }
-		virtual ~noncopyable() { }
-
-	private:
-
-		noncopyable(const noncopyable&);
-		void operator=(const noncopyable&);
-	};
-
 } // vmime
 
 

--- a/src/vmime/context.hpp
+++ b/src/vmime/context.hpp
@@ -106,7 +106,7 @@ protected:
 	context();
 	context(const context& ctx);
 
-	virtual context& operator=(const context& ctx);
+	context& operator=(const context& ctx);
 	void copyFrom(const context& ctx);
 
 	bool m_internationalizedEmail;

--- a/src/vmime/encoding.cpp
+++ b/src/vmime/encoding.cpp
@@ -157,7 +157,7 @@ const encoding encoding::decideImpl(
 
 	const string::difference_type length = end - begin;
 	const string::difference_type count = std::count_if(
-		begin, end, [](unsigned char x) { return x < 127; });
+		begin, end, [](unsigned char x) { return x <= 127; });
 
 	// All is in 7-bit US-ASCII --> 7-bit (or Quoted-Printable...)
 	if (length == count) {

--- a/src/vmime/encoding.cpp
+++ b/src/vmime/encoding.cpp
@@ -157,9 +157,7 @@ const encoding encoding::decideImpl(
 
 	const string::difference_type length = end - begin;
 	const string::difference_type count = std::count_if(
-		begin, end,
-		std::bind2nd(std::less<unsigned char>(), 127)
-	);
+		begin, end, [](unsigned char x) { return x < 127; });
 
 	// All is in 7-bit US-ASCII --> 7-bit (or Quoted-Printable...)
 	if (length == count) {

--- a/src/vmime/utility/stream.hpp
+++ b/src/vmime/utility/stream.hpp
@@ -38,9 +38,12 @@ namespace utility {
 
 /** Base class for input/output stream.
   */
-class VMIME_EXPORT stream : public object, private noncopyable {
-
+class VMIME_EXPORT stream : public object {
 public:
+	stream() = default;
+	/* Presence of move-ctor/move-asg inhibits default copy-ctor/copy-asg */
+	stream(stream &&) = default;
+	stream &operator=(stream &&) = default;
 
 	virtual ~stream() { }
 

--- a/tests/parser/charsetTest.cpp
+++ b/tests/parser/charsetTest.cpp
@@ -36,6 +36,7 @@ VMIME_TEST_SUITE_BEGIN(charsetTest)
 		VMIME_TEST(testConvertStreamValid)
 		VMIME_TEST(testConvertStreamExtract)
 		VMIME_TEST(testEncodingHebrew1255)
+		//VMIME_TEST(testEncodingSelectionOnASCII)
 
 		// IDNA
 		VMIME_TEST(testEncodeIDNA)
@@ -140,6 +141,16 @@ VMIME_TEST_SUITE_BEGIN(charsetTest)
 		// less than 60% ascii, base64 received
 		VASSERT_EQ("1", "=?windows-1255?B?6fn3+On5+Pfp6fk=?=", encoded);
 	}
+
+#if 0 /* decideImpl is not public */
+	void testEncodingSelectionOnASCII() {
+
+		const std::string a = "Hi\x01!", b = "Hi\x7f!";
+		VASSERT_EQ("1", vmime::encoding::decideImpl(std::begin(a), std::end(a)),
+		                vmime::encoding::decideImpl(std::begin(b), std::end(b)));
+
+	}
+#endif
 
 	static const vmime::string convertHelper(
 		const vmime::string& in,


### PR DESCRIPTION
Do not switch to QP/B64 when encountering U+007F.
U+007F is part of ASCII just as much as U+0001 is.

[The commit is dependent upon https://github.com/kisli/vmime/pull/302 's commit cdefae43, therefore it appears as four commits rather than one. GH can't represent this workflow when I use want to use two PRs.]