### PR TITLE
tests: switch a byte sequence in textTest

### DIFF
--- a/tests/parser/textTest.cpp
+++ b/tests/parser/textTest.cpp
@@ -168,7 +168,7 @@ VMIME_TEST_SUITE_BEGIN(textTest)
 		VASSERT_EQ("1.3", vmime::charset(vmime::charsets::US_ASCII), t1.getWordAt(0)->getCharset());
 
 		vmime::string s2_1 = "some ASCII characters and special chars: ";
-		vmime::string s2_2 = "\xf1\xf2\xf3\xf4 ";
+		vmime::string s2_2 = "\xc3\xa4\xd0\xb0 ";
 		vmime::string s2_3 = "and then more ASCII chars.";
 		vmime::string s2 = s2_1 + s2_2 + s2_3;
 		vmime::charset c2("test");
@@ -179,7 +179,7 @@ VMIME_TEST_SUITE_BEGIN(textTest)
 		VASSERT_EQ("2.1", 3, t2.getWordCount());
 		VASSERT_EQ("2.2", "some ASCII characters and special chars: ", t2.getWordAt(0)->getBuffer());
 		VASSERT_EQ("2.3", vmime::charset(vmime::charsets::US_ASCII), t2.getWordAt(0)->getCharset());
-		VASSERT_EQ("2.4", "\xf1\xf2\xf3\xf4", t2.getWordAt(1)->getBuffer());
+		VASSERT_EQ("2.4", "\xc3\xa4\xd0\xb0", t2.getWordAt(1)->getBuffer());
 		VASSERT_EQ("2.5", c2, t2.getWordAt(1)->getCharset());
 		VASSERT_EQ("2.6", "and then more ASCII chars.", t2.getWordAt(2)->getBuffer());
 		VASSERT_EQ("2.7", vmime::charset(vmime::charsets::US_ASCII), t2.getWordAt(2)->getCharset());


### PR DESCRIPTION
Switch out the byte sequence by one that is simiarly random, but one which happens to decode as valid UTF-8, such that the expected and actual strings are shown with reasonable characters on a terminal.