### PR TITLE
build: upgrade to C++17 when ICU is used

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,6 +99,23 @@ SET(CMAKE_CXX_STANDARD 11)
 SET(CMAKE_CXX_STANDARD_REQUIRED ON)
 SET(CMAKE_CXX_EXTENSIONS OFF)
 
+##############################################################################
+# Charset conversion library (1/2)
+
+INCLUDE(cmake/FindIconv.cmake)
+INCLUDE(cmake/FindICU.cmake)
+
+FIND_PACKAGE(ICU QUIET)
+
+IF(ICU_LIBRARIES)
+	SET(VMIME_CHARSETCONV_LIB_DETECTED "icu")
+	SET(CMAKE_CXX_STANDARD 17)
+ELSEIF(ICONV_FOUND)
+	SET(VMIME_CHARSETCONV_LIB_DETECTED "iconv")
+ELSEIF(WIN32)
+	SET(VMIME_CHARSETCONV_LIB_DETECTED "win")
+ENDIF()
+
 # Source files
 FILE(
 	GLOB_RECURSE
@@ -666,20 +683,7 @@ ENDIF(VMIME_HAVE_TLS_SUPPORT)
 
 
 ##############################################################################
-# Charset conversion library
-
-INCLUDE(cmake/FindIconv.cmake)
-INCLUDE(cmake/FindICU.cmake)
-
-FIND_PACKAGE(ICU QUIET)
-
-IF(ICU_LIBRARIES)
-	SET(VMIME_CHARSETCONV_LIB_DETECTED "icu")
-ELSEIF(ICONV_FOUND)
-	SET(VMIME_CHARSETCONV_LIB_DETECTED "iconv")
-ELSEIF(WIN32)
-	SET(VMIME_CHARSETCONV_LIB_DETECTED "win")
-ENDIF()
+# Charset conversion library (2/2)
 
 SET(
 	VMIME_CHARSETCONV_LIB


### PR DESCRIPTION
ICU 75 requires the use of C++17.

`SET(CMAKE_CXX_STANDARD 17)` has no effect after the first target has been defined or so, therefore the detection of the conversion library is split and partially moved upwards.