### PR TITLE
Fix a test failure in pathTest::testGenerate

### DIFF
--- a/src/vmime/emailAddress.cpp
+++ b/src/vmime/emailAddress.cpp
@@ -596,27 +596,15 @@ void emailAddress::generateImpl(
 	}
 
 
-	if (!domainPart.empty()) {
-		os << localPart
-			<< "@"
-			<< domainPart;
+	os << localPart
+		<< "@"
+		<< domainPart;
 
-		if (newLinePos) {
-			*newLinePos = curLinePos
-				+ localPart.length()
-				+ 1 // @
-				+ domainPart.length();
-		}
-	} else {
-		// this should only be true if m_useMyHostname is false and an address without
-		// an `@` is encountered
-
-		os << localPart;
-
-		if (newLinePos) {
-			*newLinePos = curLinePos
-				+ localPart.length();
-		}
+	if (newLinePos) {
+		*newLinePos = curLinePos
+			+ localPart.length()
+			+ 1 // @
+			+ domainPart.length();
 	}
 }
 
@@ -710,13 +698,8 @@ const text emailAddress::toText() const {
 
 	text txt;
 	txt.appendWord(make_shared <vmime::word>(m_localName));
-
-	if (!m_domainName.isEmpty()) {
-		// this should only be skipped if m_useMyHostname is false and an address without
-		// an `@` is encountered
-		txt.appendWord(make_shared <vmime::word>("@", vmime::charsets::US_ASCII));
-		txt.appendWord(make_shared <vmime::word>(m_domainName));
-	}
+	txt.appendWord(make_shared <vmime::word>("@", vmime::charsets::US_ASCII));
+	txt.appendWord(make_shared <vmime::word>(m_domainName));
 
 	return txt;
 }

--- a/src/vmime/path.cpp
+++ b/src/vmime/path.cpp
@@ -192,16 +192,6 @@ void path::generateImpl(
 			*newLinePos = curLinePos + 2;
 		}
 
-	} else if (!m_localPart.empty() && m_domain.empty()) {
-		// this should only be true if m_useMyHostname is false and an address without
-		// an `@` is encountered
-
-		os << "<" << m_localPart << ">";
-
-		if (newLinePos) {
-			*newLinePos = curLinePos + m_localPart.length() + 2;
-		}
-
 	} else {
 
 		os << "<" << m_localPart << "@" << m_domain << ">";

--- a/tests/parser/textTest.cpp
+++ b/tests/parser/textTest.cpp
@@ -191,7 +191,7 @@ VMIME_TEST_SUITE_BEGIN(textTest)
 		VASSERT_EQ("2.1", 3, t2.getWordCount());
 		VASSERT_EQ("2.2", "some ASCII characters and special chars:", t2.getWordAt(0)->getBuffer());
 		VASSERT_EQ("2.3", vmime::charset(vmime::charsets::US_ASCII), t2.getWordAt(0)->getCharset());
-		VASSERT_EQ("2.4", "\xc3\xa4\xd0\xb0", t2.getWordAt(1)->getBuffer());
+		VASSERT_EQ("2.4", " \xc3\xa4\xd0\xb0", t2.getWordAt(1)->getBuffer());
 		VASSERT_EQ("2.5", c2, t2.getWordAt(1)->getCharset());
 		VASSERT_EQ("2.6", " and then more ASCII chars.", t2.getWordAt(2)->getBuffer());
 		VASSERT_EQ("2.7", vmime::charset(vmime::charsets::US_ASCII), t2.getWordAt(2)->getCharset());


### PR DESCRIPTION
Partially revert v0.9.2-183-g9b65b4de.

As per RFC 5322 §3.4.1, an email address must always have a @.
As per RFC 5321 §4.1.2, a path is similar to an email address (always
@), with "" (<>) being the only other special value.

Fixes #294, #301.