### PR TITLE
fix: m_parent should be initialized using nullptr

### DIFF
--- a/src/vmime/bodyPart.hpp
+++ b/src/vmime/bodyPart.hpp
@@ -109,7 +109,7 @@ private:
 
 	// We can't use a weak_ptr<> here as the parent part may
 	// have been allocated on the stack
-	bodyPart* m_parent;
+	bodyPart* m_parent = nullptr;
 
 protected:
 


### PR DESCRIPTION
Raw pointers should always initialize by the developer, not relying on the compiler. If not, this will cause segment fault on some platforms (mingw_w64).