### PR TITLE
Implementation of initial responses with GNU SASL (resolves #319)

### DIFF
--- a/src/vmime/net/imap/IMAPConnection.cpp
+++ b/src/vmime/net/imap/IMAPConnection.cpp
@@ -331,12 +331,24 @@ void IMAPConnection::authenticateSASL() {
 
 	const std::vector <string> capa = getCapabilities();
 	std::vector <string> saslMechs;
+	bool saslIR = false;
 
 	for (unsigned int i = 0 ; i < capa.size() ; ++i) {
 
 		const string& x = capa[i];
 
-		if (x.length() > 5 &&
+		if (x.length() == 7 &&
+		    (x[0] == 'S' || x[0] == 's') &&
+		    (x[1] == 'A' || x[1] == 'a') &&
+		    (x[2] == 'S' || x[2] == 's') &&
+		    (x[3] == 'L' || x[3] == 'l') &&
+		    x[4] == '-' &&
+		    (x[5] == 'I' || x[5] == 'i') &&
+		    (x[6] == 'R' || x[6] == 'r')) {
+
+			saslIR = true;
+		}
+		else if (x.length() > 5 &&
 		    (x[0] == 'A' || x[0] == 'a') &&
 		    (x[1] == 'U' || x[1] == 'u') &&
 		    (x[2] == 'T' || x[2] == 't') &&
@@ -397,7 +409,7 @@ void IMAPConnection::authenticateSASL() {
 
 		shared_ptr <IMAPCommand> authCmd;
 
-		if (saslSession->getMechanism()->hasInitialResponse()) {
+		if (saslIR && saslSession->getMechanism()->hasInitialResponse()) {
 
 			byte_t* initialResp = 0;
 			size_t initialRespLen = 0;

--- a/src/vmime/security/sasl/builtinSASLMechanism.cpp
+++ b/src/vmime/security/sasl/builtinSASLMechanism.cpp
@@ -38,6 +38,25 @@
 
 #include <stdexcept>
 #include <new>
+#include <unordered_set>
+
+namespace {
+	const std::unordered_set<std::string> CLIENT_FIRST_MECHANISMS{
+		"ANONYMOUS",
+		"EXTERNAL",
+		"GS2-KRB5",
+		"GSSAPI",
+		"LOGIN",
+		"NTLM",
+		"OPENID20",
+		"PLAIN",
+		"SAML20",
+		"SCRAM-SHA-1",
+		"SCRAM-SHA-256",
+		"SECURID"
+	};
+	const auto CLIENT_FIRST_MECHANISMS_END = CLIENT_FIRST_MECHANISMS.cend();
+}
 
 
 namespace vmime {
@@ -51,7 +70,8 @@ builtinSASLMechanism::builtinSASLMechanism(
 )
 	: m_context(ctx),
 	  m_name(name),
-	  m_complete(false) {
+	  m_complete(false),
+	  m_initialResponse(CLIENT_FIRST_MECHANISMS.find(name) != CLIENT_FIRST_MECHANISMS_END) {
 
 }
 
@@ -140,8 +160,7 @@ bool builtinSASLMechanism::isComplete() const {
 
 bool builtinSASLMechanism::hasInitialResponse() const {
 
-	// It seems GNU SASL does not support initial response
-	return false;
+	return m_initialResponse;
 }
 
 

--- a/src/vmime/security/sasl/builtinSASLMechanism.hpp
+++ b/src/vmime/security/sasl/builtinSASLMechanism.hpp
@@ -92,6 +92,9 @@ private:
 
 	/** Authentication process status. */
 	bool m_complete;
+	
+	/** Whether the mechanism is client-first, and thus supports an initial response. */
+	bool m_initialResponse;
 };
 
 


### PR DESCRIPTION
Implements initial responses with GNU SASL.
Guards its usage within IMAP by respecting SASL-IR capability of server.