### PR TITLE
generateRandomBytes is faulty

### DIFF
--- a/src/vmime/platforms/posix/posixHandler.cpp
+++ b/src/vmime/platforms/posix/posixHandler.cpp
@@ -275,17 +275,20 @@ shared_ptr <vmime::utility::childProcessFactory> posixHandler::getChildProcessFa
 void posixHandler::generateRandomBytes(unsigned char* buffer, const unsigned int count) {
 
 	int fd = open("/dev/urandom", O_RDONLY);
+	ssize_t have = 0;
 
 	if (fd != -1) {
 
-		read(fd, buffer, count);
+		have = read(fd, buffer, count);
 		close(fd);
+		if (have < 0)
+			have = 0;
 
-	} else {  // fallback
+	}
 
-		for (unsigned int i = 0 ; i < count ; ++i) {
-			buffer[i] = static_cast <unsigned char>(rand() % 255);
-		}
+	// fallback
+	for (unsigned int i = have ; i < count ; ++i) {
+		buffer[i] = static_cast <unsigned char>(rand() % 255);
 	}
 }
 

--- a/src/vmime/platforms/posix/posixHandler.cpp
+++ b/src/vmime/platforms/posix/posixHandler.cpp
@@ -288,7 +288,7 @@ void posixHandler::generateRandomBytes(unsigned char* buffer, const unsigned int
 
 	// fallback
 	for (unsigned int i = have ; i < count ; ++i) {
-		buffer[i] = static_cast <unsigned char>(rand() % 255);
+		buffer[i] = static_cast <unsigned char>(rand() % 256);
 	}
 }
 


### PR DESCRIPTION
* not checking read() result leads to undefined bytes in the output; fill them up with the fallback loop
* fallback loop erroneously uses %255; this produces a non-uniform distribution of the result