### PR TITLE
Use ASN1_STRING_get0_data

### DIFF
--- a/src/vmime/security/cert/openssl/X509Certificate_OpenSSL.cpp
+++ b/src/vmime/security/cert/openssl/X509Certificate_OpenSSL.cpp
@@ -468,7 +468,7 @@ bool X509Certificate_OpenSSL::verifyHostName(
 		if (currentName->type == GEN_DNS) {
 
 			// Current name is a DNS name, let's check it
-			char *DNSName = (char *) ASN1_STRING_data(currentName->d.dNSName);
+			const char *DNSName = (const char *) ASN1_STRING_get0_data(currentName->d.dNSName);
 
 			// Make sure there isn't an embedded NUL character in the DNS name
 			if (ASN1_STRING_length(currentName->d.dNSName) != strlen(DNSName)) {


### PR DESCRIPTION
`ASN1_STRING_data()` has been deprecated in favor of its const correct replacement `ASN1_STRING_get0_data()` since OpenSSL 1.1. A recent change [removed][1] `ASN1_STRING_data()` from OpenSSL.

`ASN1_STRING_get0_data()` has been available in all the major forks of OpenSSL for a long time, so this only introduces a compatibility problem if vmime still supports OpenSSL <= 1.0.2, in which case I can add a compat define.

[1]: https://github.com/openssl/openssl/pull/29149