### PR TITLE
generic implementation for getThreadId for POSIX

### DIFF
--- a/src/vmime/platform.hpp
+++ b/src/vmime/platform.hpp
@@ -93,7 +93,7 @@ public:
 		  *
 		  * @return current thread id
 		  */
-		virtual unsigned int getThreadId() const = 0;
+		virtual uintptr_t getThreadId() const = 0;
 
 		/** Return the charset used on the system.
 		  *

--- a/src/vmime/platforms/posix/posixHandler.cpp
+++ b/src/vmime/platforms/posix/posixHandler.cpp
@@ -240,7 +240,14 @@ uintptr_t posixHandler::getThreadId() const {
 #elif VMIME_HAVE_LWP_SELF  // Solaris
 	return ::_lwp_self();
 #else
-	#error We have no implementation of getThreadId() for this platform!
+	/*
+	 * pthread_self's return value type can be anything:
+	 * - if it is arithmetic (glibc-nptl), static_cast<> would be needed,
+	 * - if it is a pointer (cygwin-libc, FreeBSD-libc), reinterpret_cast<> would be needed.
+	 * - if it is aggregate, there is no solution at this time
+	 * A C-style cast should cover the first two cases.
+	 */
+	return (uintptr_t) pthread_self();
 #endif
 
 }

--- a/src/vmime/platforms/posix/posixHandler.cpp
+++ b/src/vmime/platforms/posix/posixHandler.cpp
@@ -225,20 +225,20 @@ unsigned int posixHandler::getProcessId() const {
 }
 
 
-unsigned int posixHandler::getThreadId() const {
+uintptr_t posixHandler::getThreadId() const {
 
 #if VMIME_HAVE_GETTID
-	return static_cast <unsigned int>(::gettid());
+	return ::gettid();
 #elif VMIME_HAVE_SYSCALL && VMIME_HAVE_SYSCALL_GETTID
-	return static_cast <unsigned int>(::syscall(SYS_gettid));
+	return ::syscall(SYS_gettid);
 #elif VMIME_HAVE_GETTHRID  // OpenBSD
-	return static_cast <unsigned int>(::getthrid());
+	return ::getthrid();
 #elif VMIME_HAVE_THR_SELF  // FreeBSD
 	long id = 0;
 	::thr_self(&id);
-	return static_cast <unsigned int>(id);
+	return id;
 #elif VMIME_HAVE_LWP_SELF  // Solaris
-	return static_cast <unsigned int>(::_lwp_self());
+	return ::_lwp_self();
 #else
 	#error We have no implementation of getThreadId() for this platform!
 #endif

--- a/src/vmime/platforms/posix/posixHandler.hpp
+++ b/src/vmime/platforms/posix/posixHandler.hpp
@@ -64,7 +64,7 @@ public:
 	const vmime::string getHostName() const;
 
 	unsigned int getProcessId() const;
-	unsigned int getThreadId() const;
+	uintptr_t getThreadId() const;
 
 #if VMIME_HAVE_MESSAGING_FEATURES
 	shared_ptr <vmime::net::socketFactory> getSocketFactory();

--- a/src/vmime/platforms/windows/windowsHandler.cpp
+++ b/src/vmime/platforms/windows/windowsHandler.cpp
@@ -258,9 +258,9 @@ unsigned int windowsHandler::getProcessId() const {
 }
 
 
-unsigned int windowsHandler::getThreadId() const {
+uintptr_t windowsHandler::getThreadId() const {
 
-	return static_cast <unsigned int>(::GetCurrentThreadId());
+	return ::GetCurrentThreadId();
 }
 
 

--- a/src/vmime/platforms/windows/windowsHandler.hpp
+++ b/src/vmime/platforms/windows/windowsHandler.hpp
@@ -63,7 +63,7 @@ public:
 	const vmime::string getHostName() const;
 
 	unsigned int getProcessId() const;
-	unsigned int getThreadId() const;
+	uintptr_t getThreadId() const;
 
 #if VMIME_HAVE_MESSAGING_FEATURES
 	shared_ptr <vmime::net::socketFactory> getSocketFactory();


### PR DESCRIPTION
* Switch getThreadId to return uintptr_t:
   Some threading implementations are lightweight/do not have a corresponding PID-like identifier for them, but only a memory handle. This necessitates using a type that is a typical register wide.
* Provide a generic implementation for getThreadId() on POSIX using pthread_self